### PR TITLE
OPS-7191 Fixes issue where deploy script would not properly check for files no…

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -50,7 +50,7 @@ done
 
 files=${DEPLOY_FILES:-$discovered_files}
 
-if [[ -z "$files" ]]
+if [[ -z "${files// }" ]]
 then
     echo "Files not found; not deploying."
     exit 1


### PR DESCRIPTION
…t being found in the DEPLOY_SOURCE_DIR since the  variable was always at least 3 space characters